### PR TITLE
Update specter to 1.7.0

### DIFF
--- a/app-system/apps.json
+++ b/app-system/apps.json
@@ -32,7 +32,7 @@
         "image": "lncm/specter-desktop",
         "name": "Specter Desktop",
         "repo": "https://github.com/cryptoadvance/specter-desktop",
-        "version": "1.6.0"
+        "version": "1.7.0"
     },
     {
         "id": "krystal-bull",


### PR DESCRIPTION
Possibly dependent on https://github.com/runcitadel/apps/pull/2 ?