### PR TITLE
electrs: set logging level

### DIFF
--- a/templates/electrs-sample.toml
+++ b/templates/electrs-sample.toml
@@ -6,6 +6,7 @@
 # Please note: This file can't be changed, it will be overwritten.
 # A few modifications will be kept, including alias, color, channel size limitations and more if you contact us.
 
+log_filters = "INFO"
 network = "bitcoin"
 db_dir = "/data/db"
 daemon_dir = "/bitcoin"


### PR DESCRIPTION
In 6b007479e02dac8f26eaf1361a94f99ac3e1b9f8 the verbose=2 option
has been reverted, since this option is not supported anymore.

However, the same verbosity level can be achieved by setting
log_filters to "INFO".