### PR TITLE
fix bitcoin network config for regtest

### DIFF
--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -8,7 +8,6 @@
 # Tor
 proxy=<tor-proxy-ip>:<tor-proxy-port>
 listen=1
-bind=<bitcoin-ip>
 
 # Mainnet/Testnet/regtest
 <bitcoin-network>=1
@@ -42,6 +41,7 @@ peerblockfilters=1
 <external-ip>
 
 <network-section>
+bind=<bitcoin-ip>
 port=<bitcoin-p2p-port>
 rpcport=<bitcoin-rpc-port>
 rpcbind=<bitcoin-ip>


### PR DESCRIPTION
Need to move this config option under the network-section header as well.