### PR TITLE
fix electrs config not using bitcoin-network env var

### DIFF
--- a/templates/electrs-sample.toml
+++ b/templates/electrs-sample.toml
@@ -7,7 +7,7 @@
 # A few modifications will be kept, including alias, color, channel size limitations and more if you contact us.
 
 log_filters = "INFO"
-network = "bitcoin"
+network = "<bitcoin-network>"
 db_dir = "/data/db"
 daemon_dir = "/bitcoin"
 daemon_rpc_addr = "<bitcoin-ip>:<bitcoin-rpc-port>"


### PR DESCRIPTION
For development it makes sense to use the `bitcoin-network` env var for the electrum server config. Right now it is hardcoded for mainnet.

TODO:
- [ ] for mainnet it needs to resolve to "bitcoin"
