### PR TITLE
fix: Include service definitions in updates

### DIFF
--- a/scripts/update/.updateinclude
+++ b/scripts/update/.updateinclude
@@ -6,3 +6,6 @@ tor/torrc-apps-3
 tor/torrc-core
 electrs/electrs.toml
 apps/docker-compose.common.yml
+services/bitcoin/*
+services/electrum/*
+services/lightning/*


### PR DESCRIPTION
Because we ignored the bitcoin dir in the `.updateignore`, we also ignored `services/bitcoin` for updates, leading to users updating from older versions experiencing issues.

I now added all 3 dirs in `services` to `.updateinclude` to avoid this and potential future problems if we decide to rename the lnd or electrs directory.