### PR TITLE
Fix app generation

### DIFF
--- a/app/lib/composegenerator/v3/types.py
+++ b/app/lib/composegenerator/v3/types.py
@@ -38,7 +38,7 @@ class Container:
     port: Union[int, None] = None
     requiredPorts: list = field(default_factory=list)
     requiredUdpPorts: list = field(default_factory=list)
-    preferredOutsidePort: Union[int, None] = None
+    #preferredOutsidePort: Union[int, None] = None
     requiresPort: Union[bool, None] = None
     environment: Union[dict, None] = None
     data: list = field(default_factory=list)


### PR DESCRIPTION
This prevents preferredOutsidePort from being added into the final compose. It is ignored during composegenerator's runtime, so it can be safely removed from the dataclasses used during build, so it is also not included in the final output