### PR TITLE
Add support for BOS

### DIFF
--- a/setenv
+++ b/setenv
@@ -13,3 +13,5 @@ alias docker-compose="sudo docker compose"
 alias docker="sudo docker"
 alias debug="${CITADEL_ROOT}/scripts/debug"
 alias app="${CITADEL_ROOT}/scripts/app"
+
+export BOS_DEFAULT_LND_PATH="/home/citadel/citadel/lnd"


### PR DESCRIPTION
This makes it easier to install BOS on the host. The setenv script is run on every shell open on every Citadel OS install by default.