### PR TITLE
Small fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   tor:
     container_name: tor
-    image: lncm/tor:0.4.7.7@sha256:3c4ae833d2fefbea7d960f833a1e89fc9b2069a6e5f360109b5ddc9334ac0227
+    image: lncm/tor:0.4.7.8@sha256:aab30ebb496aa25934d6096951d8b200347c3c3ce5db3493695229efa2601f7b
     user: toruser
     restart: on-failure
     volumes:
@@ -15,7 +15,7 @@ services:
         ipv4_address: $TOR_PROXY_IP
   app-tor:
     container_name: app-tor
-    image: lncm/tor:0.4.7.7@sha256:3c4ae833d2fefbea7d960f833a1e89fc9b2069a6e5f360109b5ddc9334ac0227
+    image: lncm/tor:0.4.7.8@sha256:aab30ebb496aa25934d6096951d8b200347c3c3ce5db3493695229efa2601f7b
     user: toruser
     restart: on-failure
     volumes:
@@ -26,7 +26,7 @@ services:
         ipv4_address: $APPS_TOR_IP
   app-2-tor:
     container_name: app-2-tor
-    image: lncm/tor:0.4.7.7@sha256:3c4ae833d2fefbea7d960f833a1e89fc9b2069a6e5f360109b5ddc9334ac0227
+    image: lncm/tor:0.4.7.8@sha256:aab30ebb496aa25934d6096951d8b200347c3c3ce5db3493695229efa2601f7b
     user: toruser
     restart: on-failure
     volumes:
@@ -37,7 +37,7 @@ services:
         ipv4_address: $APPS_2_TOR_IP
   app-3-tor:
     container_name: app-3-tor
-    image: lncm/tor:0.4.7.7@sha256:3c4ae833d2fefbea7d960f833a1e89fc9b2069a6e5f360109b5ddc9334ac0227
+    image: lncm/tor:0.4.7.8@sha256:aab30ebb496aa25934d6096951d8b200347c3c3ce5db3493695229efa2601f7b
     user: toruser
     restart: on-failure
     volumes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.0.5",
-    "name": "Citadel 0.0.5",
+    "version": "0.0.6",
+    "name": "Citadel 0.0.6",
     "requires": ">=0.0.1",
-    "notes": "This update fixes a few bugs in the 0.0.4 release that were preventing some apps from working correctly."
+    "notes": "This update fixes a security issue in Tor which could lead to slower Tor performance or your node being inaccessible via Tor."
 }

--- a/scripts/configure
+++ b/scripts/configure
@@ -233,11 +233,7 @@ neutrino.addpeer=testnet2-btcd.zaphq.io
 elif BITCOIN_NETWORK == "signet":
   BITCOIN_RPC_PORT=38332
   BITCOIN_P2P_PORT=38333
-  NEUTRINO_PEERS='''
-[neutrino]
-neutrino.addpeer=testnet1-btcd.zaphq.io
-neutrino.addpeer=testnet2-btcd.zaphq.io
-  '''
+  BITCOIN_NODE="bitcoind"
 elif BITCOIN_NETWORK == "regtest":
   BITCOIN_RPC_PORT=18334
   BITCOIN_P2P_PORT=18335

--- a/setenv
+++ b/setenv
@@ -7,7 +7,7 @@
 CITADEL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))"
 
 alias citadel-update="${CITADEL_ROOT}/scripts/update/update"
-alias lncli="docker exec -it lnd lncli"
+alias lncli="docker exec -it lightning lncli"
 alias bitcoin-cli="docker exec -it bitcoin bitcoin-cli"
 alias docker-compose="sudo docker compose"
 alias docker="sudo docker"


### PR DESCRIPTION
- use bitcoind for signet
- fix lncli alias

At the point of this writing the blockchain size on Signet is 554MB. So the sync is pretty fast and it's unnecessary to use neutrino and wait for an hour for the neutrino-switcher to switch the backend. I'm also not 100% sure if neutrino even works on Signet.