### PR TITLE
Preprocess app.yml.jinja files

### DIFF
--- a/app/lib/validate.py
+++ b/app/lib/validate.py
@@ -73,6 +73,7 @@ def findAndValidateApps(dir: str):
             continue
         app_dir = subdir.path
         if os.path.isfile(os.path.join(app_dir, "app.yml.jinja")):
+            os.chown(os.path.join(app_dir, "app.yml.jinja"), 1000, 1000)
             os.system("docker run --rm -v {}:/apps -u 1000:1000 {} /app-cli preprocess --app-name '{}' --port-map /apps/ports.json /apps/{}/app.yml.jinja /apps/{}/app.yml --services 'lnd'".format(dir, dependencies['app-cli'], subdir.name, subdir.name, subdir.name))
         if os.path.isfile(os.path.join(app_dir, "app.yml")):
             apps.append(subdir.name)

--- a/app/lib/validate.py
+++ b/app/lib/validate.py
@@ -73,7 +73,7 @@ def findAndValidateApps(dir: str):
             continue
         app_dir = subdir.path
         if os.path.isfile(os.path.join(app_dir, "app.yml.jinja")):
-            os.chown(os.path.join(app_dir, "app.yml.jinja"), 1000, 1000)
+            os.chown(app_dir, 1000, 1000)
             os.system("docker run --rm -v {}:/apps -u 1000:1000 {} /app-cli preprocess --app-name '{}' --port-map /apps/ports.json /apps/{}/app.yml.jinja /apps/{}/app.yml --services 'lnd'".format(dir, dependencies['app-cli'], subdir.name, subdir.name, subdir.name))
         if os.path.isfile(os.path.join(app_dir, "app.yml")):
             apps.append(subdir.name)

--- a/app/lib/validate.py
+++ b/app/lib/validate.py
@@ -9,11 +9,15 @@ import yaml
 import traceback
 
 scriptDir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+nodeRoot = os.path.join(scriptDir, "..")
 
 with open(os.path.join(scriptDir, 'app-standard-v2.yml'), 'r') as f:
     schemaVersion2 = yaml.safe_load(f)
 with open(os.path.join(scriptDir, 'app-standard-v3.yml'), 'r') as f:
     schemaVersion3 = yaml.safe_load(f)
+
+with open(os.path.join(nodeRoot, "db", "dependencies.yml"), "r") as file: 
+  dependencies = yaml.safe_load(file)
 
 # Validates app data
 # Returns true if valid, false otherwise
@@ -68,6 +72,8 @@ def findAndValidateApps(dir: str):
         if not subdir.is_dir():
             continue
         app_dir = subdir.path
+        if os.path.isfile(os.path.join(app_dir, "app.yml.jinja")):
+            os.system("docker run --rm -v {}:/apps -u 1000:1000 {} /app-cli preprocess --app-name '{}' --port-map /apps/ports.json /apps/{}/app.yml.jinja /apps/{}/app.yml --services 'lnd'".format(dir, dependencies['app-cli'], app, app, app))
         if os.path.isfile(os.path.join(app_dir, "app.yml")):
             apps.append(subdir.name)
             # Read the app.yml and append it to app_data

--- a/app/lib/validate.py
+++ b/app/lib/validate.py
@@ -73,7 +73,7 @@ def findAndValidateApps(dir: str):
             continue
         app_dir = subdir.path
         if os.path.isfile(os.path.join(app_dir, "app.yml.jinja")):
-            os.system("docker run --rm -v {}:/apps -u 1000:1000 {} /app-cli preprocess --app-name '{}' --port-map /apps/ports.json /apps/{}/app.yml.jinja /apps/{}/app.yml --services 'lnd'".format(dir, dependencies['app-cli'], app, app, app))
+            os.system("docker run --rm -v {}:/apps -u 1000:1000 {} /app-cli preprocess --app-name '{}' --port-map /apps/ports.json /apps/{}/app.yml.jinja /apps/{}/app.yml --services 'lnd'".format(dir, dependencies['app-cli'], subdir.name, subdir.name, subdir.name))
         if os.path.isfile(os.path.join(app_dir, "app.yml")):
             apps.append(subdir.name)
             # Read the app.yml and append it to app_data

--- a/db/dependencies.yml
+++ b/db/dependencies.yml
@@ -2,4 +2,4 @@ compose: v2.6.0
 dashboard: ghcr.io/runcitadel/dashboard:main@sha256:25b6fb413c10f47e186309c8737926c241c0f2bec923b2c08dd837b828f14dbd
 manager: ghcr.io/runcitadel/manager:main@sha256:db5775e986d53e762e43331540bb1c05a27b362da94d587c4a4591c981c00ee4
 middleware: ghcr.io/runcitadel/middleware:main@sha256:2fbbfb2e818bf0462f74a6aaab192881615ae018e6dcb62a50d05f82ec622cb0
-app-cli: ghcr.io/runcitadel/app-cli:main@sha256:f532923eac28cfac03579cbb440397bcf16c8730f291b39eeada8278331f7054
+app-cli: ghcr.io/runcitadel/app-cli:main@sha256:651c0710785e89f7124b37c58af05c5577d06d8e8a680bb2c800b1bb83963bc8

--- a/db/dependencies.yml
+++ b/db/dependencies.yml
@@ -2,4 +2,4 @@ compose: v2.6.0
 dashboard: ghcr.io/runcitadel/dashboard:main@sha256:25b6fb413c10f47e186309c8737926c241c0f2bec923b2c08dd837b828f14dbd
 manager: ghcr.io/runcitadel/manager:main@sha256:db5775e986d53e762e43331540bb1c05a27b362da94d587c4a4591c981c00ee4
 middleware: ghcr.io/runcitadel/middleware:main@sha256:2fbbfb2e818bf0462f74a6aaab192881615ae018e6dcb62a50d05f82ec622cb0
-app-cli: ghcr.io/runcitadel/app-cli:main@sha256:651c0710785e89f7124b37c58af05c5577d06d8e8a680bb2c800b1bb83963bc8
+app-cli: ghcr.io/runcitadel/app-cli:main@sha256:79a99263643b129ccbc2a09d48d4820ab97c04d72c2f986daa6cb544474a54ad


### PR DESCRIPTION
This allows people to write app.yml.jinja files, these can contain dynamic env vars based on installed services (for example CLN/LND). This makes the app.yml format simpler and removes unused containers at a earlier stage, which results in them not even getting an IP address assigned, meaning we have more IP addresses available.